### PR TITLE
Ignore django migration files when linting

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,8 +64,8 @@ async function getModifiedPythonFiles(baseBranch) {
     "--name-only",
     "--diff-filter=AMRC",
     baseBranch,
-    '--',
-    '.',
+    "--",
+    ".",
     "':!*/migrations/*'",
   ]);
 

--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ async function getModifiedPythonFiles(baseBranch) {
     "--name-only",
     "--diff-filter=AMRC",
     baseBranch,
+    '--',
+    '.',
+    "':!*/migrations/*'",
   ]);
 
   return files.split("\n").filter((filename) => filename.endsWith(".py"));


### PR DESCRIPTION
Maybe not super flexible since it does not read the pylintrc file, but it should work.